### PR TITLE
Resolves Compilation Error on Arduino IDE

### DIFF
--- a/src/EventEmitter/EventEmitter.h
+++ b/src/EventEmitter/EventEmitter.h
@@ -1,3 +1,4 @@
+#include <vector>
 #include <map>
 #include "Listener.h"
 


### PR DESCRIPTION
Following Compilation Error is resolved:<br>
EventEmitter.h:14:8: <br>error: 'vector' in namespace 'std' does not name a template type